### PR TITLE
hello-world service port number is fixed in curl test

### DIFF
--- a/README.ftl.md
+++ b/README.ftl.md
@@ -146,7 +146,7 @@ Test it:
 ```
 $ curl localhost:8080/hello-world
 curl: (7) couldn't connect to host
-$ curl localhost:9001/hello-world
+$ curl localhost:9000/hello-world
 {"id":1,"content":"Hello, Stranger!"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Test it:
 ```
 $ curl localhost:8080/hello-world
 curl: (7) couldn't connect to host
-$ curl localhost:9001/hello-world
+$ curl localhost:9000/hello-world
 {"id":1,"content":"Hello, Stranger!"}
 ```
 


### PR DESCRIPTION
the last test in README where the reconfigured port number is tested with curl, the `hello-world` service's port is misstyped.
