### PR TITLE
Change link to point to Spring Boot user guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ projects: [spring-boot]
 :source-highlighter: prettify
 :project_id: gs-actuator-service
 
-https://github.com/spring-projects/spring-boot/tree/master/spring-boot-actuator[Spring Boot Actuator] is a sub-project of Spring Boot. It adds several production grade services to your application with little effort on your part. In this guide, you'll build an application and then see how to add these services.
+http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator] is a sub-project of Spring Boot. It adds several production grade services to your application with little effort on your part. In this guide, you'll build an application and then see how to add these services.
 
 == What you'll build
 


### PR DESCRIPTION
This document was written before the Boot usre guide existed, so the link is
stale.

See https://github.com/spring-projects/spring-boot/issues/1014
